### PR TITLE
Add typst import logic

### DIFF
--- a/typst_importer/__init__.py
+++ b/typst_importer/__init__.py
@@ -36,7 +36,7 @@ class ImportTypstOperator(bpy.types.Operator, ImportHelper):
         # Start timing
         start_time = time.perf_counter()
 
-        # Create a temp SVG path that includes the original file name
+        # Create a temp SVG path
         temp_dir = Path(tempfile.gettempdir())
         svg_file_name = f"{file_name_without_ext}.svg"
         svg_file = temp_dir / svg_file_name
@@ -48,8 +48,7 @@ class ImportTypstOperator(bpy.types.Operator, ImportHelper):
         bpy.ops.import_curve.svg(filepath=str(svg_file))
 
         # Rename the newly created Collection
-        # By default, Blender creates a new collection named after the file name
-        # e.g. 'myfile.svg'
+        # By default, the new collection is named after the file name e.g. 'myfile.svg'
         imported_collection = bpy.context.scene.collection.children.get(svg_file_name)
         if imported_collection:
             imported_collection.name = f"Formula_{file_name_without_ext}"
@@ -62,7 +61,7 @@ class ImportTypstOperator(bpy.types.Operator, ImportHelper):
         elapsed_time_ms = (time.perf_counter() - start_time) * 1000
 
         self.report(
-            {"INFO"}, f" 🐻‍❄️ 📥  Added {typst_file.name} in {elapsed_time_ms:.2f} ms"
+            {"INFO"}, f" 🦢  Added {typst_file.name} in {elapsed_time_ms:.2f} ms"
         )
         return {"FINISHED"}
 
@@ -86,39 +85,22 @@ class TXT_FH_import(bpy.types.FileHandler):
 
     @classmethod
     def poll_drop(cls, context):
-        # Allow drag-and-drop in the 3D View
+        # Allow drag-and-drop
         return context.area
 
 
 def menu_func_import(self, context):
     """Function to add an entry into the File > Import menu."""
-    self.layout.operator(ImportTypstOperator.bl_idname, text="TXT via Typst (.txt)")
-
-
-class HelloWorldWorldPanel(bpy.types.Panel):
-    """A simple test panel under the World tab in the Properties."""
-
-    bl_label = "Hello World Panel"
-    bl_idname = "WORLD_PT_hello_world"
-    bl_space_type = "PROPERTIES"
-    bl_region_type = "WINDOW"
-    bl_context = "world"
-
-    def draw(self, context):
-        layout = self.layout
-        layout.label(text="Hello World!")
-        layout.operator(ImportTypstOperator.bl_idname, text="Import TXT 🐻")
+    self.layout.operator(ImportTypstOperator.bl_idname, text="Typst 🦢 via (.txt)")
 
 
 def register():
     bpy.utils.register_class(ImportTypstOperator)
     bpy.utils.register_class(TXT_FH_import)
     bpy.types.TOPBAR_MT_file_import.append(menu_func_import)
-    bpy.utils.register_class(HelloWorldWorldPanel)
 
 
 def unregister():
-    bpy.utils.unregister_class(HelloWorldWorldPanel)
     bpy.types.TOPBAR_MT_file_import.remove(menu_func_import)
     bpy.utils.unregister_class(TXT_FH_import)
     bpy.utils.unregister_class(ImportTypstOperator)

--- a/typst_importer/__init__.py
+++ b/typst_importer/__init__.py
@@ -21,6 +21,7 @@ class ImportCsvPolarsOperator(bpy.types.Operator, ImportHelper):
     bl_label = "Import CSV (Polars)"
     bl_options = {"PRESET", "UNDO"}
 
+    print("ImportCsvPolarsOperator")
     # ImportHelper mix-in provides 'filepath' by default, but we redefine it here
     # to use SKIP_SAVE, allowing drag-and-drop to work properly.
     filepath: StringProperty(subtype="FILE_PATH", options={"SKIP_SAVE"})

--- a/typst_importer/__init__.py
+++ b/typst_importer/__init__.py
@@ -36,21 +36,13 @@ class ImportCsvPolarsOperator(bpy.types.Operator, ImportHelper):
             return {"CANCELLED"}
 
         # Use the selected/dropped file path
-        csv_file = Path(self.filepath)
-        file_name_without_ext = csv_file.stem
+        typst_file = Path(self.filepath)
+        file_name_without_ext = typst_file.stem
         start_time = time.perf_counter()
 
         temp_dir = Path(tempfile.gettempdir())
-
-        typst_file = temp_dir / "hello.typ"
         svg_file = temp_dir / "hello.svg"
 
-        file_content = """
-        #set page(width: auto, height: auto, margin: 0cm, fill: none)
-        #set text(size: 5000pt)
-        $ sum_(k=1)^n k = (n(n+1)) / 2 $
-        """
-        typst_file.write_text(file_content)
         typst.compile(typst_file, format="svg", output=str(svg_file))
 
         bpy.ops.import_curve.svg(filepath=str(svg_file))
@@ -61,7 +53,7 @@ class ImportCsvPolarsOperator(bpy.types.Operator, ImportHelper):
 
         self.report(
             {"INFO"},
-            f" 🐻‍❄️ 📥  Added {csv_file} in {elapsed_time_ms:.2f} ms",
+            f" 🐻‍❄️ 📥  Added {typst_file} in {elapsed_time_ms:.2f} ms",
         )
         return {"FINISHED"}
 

--- a/typst_importer/__init__.py
+++ b/typst_importer/__init__.py
@@ -7,24 +7,22 @@ import typst
 import tempfile
 import time
 
+
 # Operator for the button and drag-and-drop
 class ImportTypstOperator(bpy.types.Operator, ImportHelper):
     """Operator to import a .txt file, compile it via Typst, and import as SVG in Blender."""
-    
+
     bl_idname = "import_scene.import_txt_typst"
     bl_label = "Import TXT (Typst)"
     bl_options = {"PRESET", "UNDO"}
-    
+
     # ImportHelper mix-in provides 'filepath' by default, but we redefine it here
     # to use SKIP_SAVE, allowing drag-and-drop to work properly.
-    filepath: StringProperty(
-        subtype="FILE_PATH",
-        options={"SKIP_SAVE"}
-    )
-    
+    filepath: StringProperty(subtype="FILE_PATH", options={"SKIP_SAVE"})
+
     filename_ext = ".txt"
     filter_glob: StringProperty(default="*.txt", options={"HIDDEN"}, maxlen=255)
-    
+
     def execute(self, context):
         # Check that it's really a .txt file
         if not self.filepath.lower().endswith(".txt"):
@@ -34,7 +32,7 @@ class ImportTypstOperator(bpy.types.Operator, ImportHelper):
         # Prepare the file variables
         typst_file = Path(self.filepath)
         file_name_without_ext = typst_file.stem
-        
+
         # Start timing
         start_time = time.perf_counter()
 
@@ -48,7 +46,7 @@ class ImportTypstOperator(bpy.types.Operator, ImportHelper):
 
         # Import the generated SVG
         bpy.ops.import_curve.svg(filepath=str(svg_file))
-        
+
         # Rename the newly created Collection
         # By default, Blender creates a new collection named after the file name
         # e.g. 'myfile.svg'
@@ -57,13 +55,14 @@ class ImportTypstOperator(bpy.types.Operator, ImportHelper):
             imported_collection.name = f"Formula_{file_name_without_ext}"
         else:
             # Fallback in case Blender changes how new collections are named
-            self.report({"WARNING"}, "Could not find the imported collection to rename.")
+            self.report(
+                {"WARNING"}, "Could not find the imported collection to rename."
+            )
 
         elapsed_time_ms = (time.perf_counter() - start_time) * 1000
 
         self.report(
-            {"INFO"},
-            f" 🐻‍❄️ 📥  Added {typst_file.name} in {elapsed_time_ms:.2f} ms"
+            {"INFO"}, f" 🐻‍❄️ 📥  Added {typst_file.name} in {elapsed_time_ms:.2f} ms"
         )
         return {"FINISHED"}
 
@@ -79,7 +78,7 @@ class ImportTypstOperator(bpy.types.Operator, ImportHelper):
 # File Handler for drag-and-drop support
 class TXT_FH_import(bpy.types.FileHandler):
     """A file handler to allow .txt files to be dragged and dropped directly into Blender."""
-    
+
     bl_idname = "TXT_FH_import"
     bl_label = "File handler for TXT import (Typst)"
     bl_import_operator = "import_scene.import_txt_typst"
@@ -87,21 +86,18 @@ class TXT_FH_import(bpy.types.FileHandler):
 
     @classmethod
     def poll_drop(cls, context):
-        # Restrict drag-and-drop to areas that make sense, e.g. 3D View
-        return context.area and context.area.type in {"VIEW_3D", "PROPERTIES"}
+        # Allow drag-and-drop in the 3D View
+        return context.area
 
 
 def menu_func_import(self, context):
     """Function to add an entry into the File > Import menu."""
-    self.layout.operator(
-        ImportTypstOperator.bl_idname, 
-        text="TXT via Typst (.txt)"
-    )
+    self.layout.operator(ImportTypstOperator.bl_idname, text="TXT via Typst (.txt)")
 
 
 class HelloWorldWorldPanel(bpy.types.Panel):
     """A simple test panel under the World tab in the Properties."""
-    
+
     bl_label = "Hello World Panel"
     bl_idname = "WORLD_PT_hello_world"
     bl_space_type = "PROPERTIES"

--- a/typst_importer/__init__.py
+++ b/typst_importer/__init__.py
@@ -5,35 +5,26 @@ from bpy.props import StringProperty
 from pathlib import Path
 import typst
 import tempfile
-import bpy
-
-from io import StringIO
-from pathlib import Path
 import time
 
-# based on the blender docs: https://docs.blender.org/api/current/bpy.types.FileHandler.html#basic-filehandler-for-operator-that-imports-just-one-file
-# and tweaked with this prompt: https://chatgpt.com/share/675b0831-354c-8013-bae0-9bb91d527f32
-
-
 # Operator for the button and drag-and-drop
-class ImportCsvPolarsOperator(bpy.types.Operator, ImportHelper):
-    bl_idname = "import_scene.import_csv_polars"
-    bl_label = "Import CSV (Polars)"
+class ImportTxtPolarsOperator(bpy.types.Operator, ImportHelper):
+    bl_idname = "import_scene.import_txt_polars"
+    bl_label = "Import TXT (Polars)"
     bl_options = {"PRESET", "UNDO"}
 
-    print("ImportCsvPolarsOperator")
+    print("ImportTxtPolarsOperator")
     # ImportHelper mix-in provides 'filepath' by default, but we redefine it here
     # to use SKIP_SAVE, allowing drag-and-drop to work properly.
     filepath: StringProperty(subtype="FILE_PATH", options={"SKIP_SAVE"})
 
-    filename_ext = ".csv"
-    filter_glob: StringProperty(default="*.csv", options={"HIDDEN"}, maxlen=255)
+    filename_ext = ".txt"
+    filter_glob: StringProperty(default="*.txt", options={"HIDDEN"}, maxlen=255)
 
     def execute(self, context):
-        # Ensure the filepath is a CSV file
-
-        if not self.filepath.lower().endswith(".csv"):
-            self.report({"WARNING"}, "Selected file is not a CSV")
+        # Ensure the filepath is a TXT file
+        if not self.filepath.lower().endswith(".txt"):
+            self.report({"WARNING"}, "Selected file is not a TXT")
             return {"CANCELLED"}
 
         # Use the selected/dropped file path
@@ -68,11 +59,11 @@ class ImportCsvPolarsOperator(bpy.types.Operator, ImportHelper):
 
 
 # File Handler for drag-and-drop support
-class CSV_FH_import(bpy.types.FileHandler):
-    bl_idname = "CSV_FH_import"
-    bl_label = "File handler for CSV import"
-    bl_import_operator = "import_scene.import_csv_polars"
-    bl_file_extensions = ".csv"
+class TXT_FH_import(bpy.types.FileHandler):
+    bl_idname = "TXT_FH_import"
+    bl_label = "File handler for TXT import"
+    bl_import_operator = "import_scene.import_txt_polars"
+    bl_file_extensions = ".txt"
 
     @classmethod
     def poll_drop(cls, context):
@@ -82,7 +73,7 @@ class CSV_FH_import(bpy.types.FileHandler):
 
 # Register the operator and menu entry
 def menu_func_import(self, context):
-    self.layout.operator(ImportCsvPolarsOperator.bl_idname, text="CSV 🐻 (.csv)")
+    self.layout.operator(ImportTxtPolarsOperator.bl_idname, text="TXT 🐻 (.txt)")
 
 
 class HelloWorldWorldPanel(bpy.types.Panel):
@@ -95,12 +86,12 @@ class HelloWorldWorldPanel(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         layout.label(text="Hello World!")
-        layout.operator(ImportCsvPolarsOperator.bl_idname, text="Import CSV 🐻")
+        layout.operator(ImportTxtPolarsOperator.bl_idname, text="Import TXT 🐻")
 
 
 def register():
-    bpy.utils.register_class(ImportCsvPolarsOperator)
-    bpy.utils.register_class(CSV_FH_import)
+    bpy.utils.register_class(ImportTxtPolarsOperator)
+    bpy.utils.register_class(TXT_FH_import)
     bpy.types.TOPBAR_MT_file_import.append(menu_func_import)
     bpy.utils.register_class(HelloWorldWorldPanel)
 
@@ -108,8 +99,8 @@ def register():
 def unregister():
     bpy.utils.unregister_class(HelloWorldWorldPanel)
     bpy.types.TOPBAR_MT_file_import.remove(menu_func_import)
-    bpy.utils.unregister_class(CSV_FH_import)
-    bpy.utils.unregister_class(ImportCsvPolarsOperator)
+    bpy.utils.unregister_class(TXT_FH_import)
+    bpy.utils.unregister_class(ImportTxtPolarsOperator)
 
 
 if __name__ == "__main__":

--- a/typst_importer/__init__.py
+++ b/typst_importer/__init__.py
@@ -8,12 +8,12 @@ import tempfile
 import time
 
 # Operator for the button and drag-and-drop
-class ImportTxtPolarsOperator(bpy.types.Operator, ImportHelper):
+class ImportTypstOperator(bpy.types.Operator, ImportHelper):
     bl_idname = "import_scene.import_txt_polars"
     bl_label = "Import TXT (Polars)"
     bl_options = {"PRESET", "UNDO"}
 
-    print("ImportTxtPolarsOperator")
+    print("ImportTypstOperator")
     # ImportHelper mix-in provides 'filepath' by default, but we redefine it here
     # to use SKIP_SAVE, allowing drag-and-drop to work properly.
     filepath: StringProperty(subtype="FILE_PATH", options={"SKIP_SAVE"})
@@ -73,7 +73,7 @@ class TXT_FH_import(bpy.types.FileHandler):
 
 # Register the operator and menu entry
 def menu_func_import(self, context):
-    self.layout.operator(ImportTxtPolarsOperator.bl_idname, text="TXT 🐻 (.txt)")
+    self.layout.operator(ImportTypstOperator.bl_idname, text="TXT 🐻 (.txt)")
 
 
 class HelloWorldWorldPanel(bpy.types.Panel):
@@ -86,11 +86,11 @@ class HelloWorldWorldPanel(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         layout.label(text="Hello World!")
-        layout.operator(ImportTxtPolarsOperator.bl_idname, text="Import TXT 🐻")
+        layout.operator(ImportTypstOperator.bl_idname, text="Import TXT 🐻")
 
 
 def register():
-    bpy.utils.register_class(ImportTxtPolarsOperator)
+    bpy.utils.register_class(ImportTypstOperator)
     bpy.utils.register_class(TXT_FH_import)
     bpy.types.TOPBAR_MT_file_import.append(menu_func_import)
     bpy.utils.register_class(HelloWorldWorldPanel)
@@ -100,7 +100,7 @@ def unregister():
     bpy.utils.unregister_class(HelloWorldWorldPanel)
     bpy.types.TOPBAR_MT_file_import.remove(menu_func_import)
     bpy.utils.unregister_class(TXT_FH_import)
-    bpy.utils.unregister_class(ImportTxtPolarsOperator)
+    bpy.utils.unregister_class(ImportTypstOperator)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is based on an earlier version of the [csv-importer](https://extensions.blender.org/add-ons/csv-importer/) extension. Here's the original csv importer logic:
https://github.com/kolibril13/blender_csv_import/blob/efb413bb50f28eadea406bc27c2cfe829b2e762b/__init__.py