### PR TITLE
Adjust Transform Geometry node `GeometryNodeTransform` configuration …

### DIFF
--- a/typst_importer/node_groups.py
+++ b/typst_importer/node_groups.py
@@ -66,7 +66,10 @@ def create_follow_curve_node_group():
 
     transform_geometry = follow_path.nodes.new("GeometryNodeTransform")
     transform_geometry.name = "Transform Geometry"
-    transform_geometry.mode = "COMPONENTS"
+    if bpy.app.version >= (5, 0, 0):
+        transform_geometry.inputs[1].default_value = 'Components'
+    else:
+        transform_geometry.mode = "COMPONENTS"
     transform_geometry.inputs[2].default_value = (0.0, 0.0, 0.0)  # Rotation
     transform_geometry.inputs[3].default_value = (1.0, 1.0, 1.0)  # Scale
 


### PR DESCRIPTION
…to support Blender 5.0

Use inputs[1].default_value = 'Components' for Blender 5.0+ (replaces deprecated mode property) Keep mode = "COMPONENTS" for pre-5.0 versions to maintain compatibility